### PR TITLE
Fix accuracy of comma-grouped selectors

### DIFF
--- a/restaurant.js
+++ b/restaurant.js
@@ -233,8 +233,8 @@ function fireRule(rule) {
 
   var baseTable = $('.table-wrapper > .table');
 
-  var ruleSelected = $(".table-wrapper " + rule).not(baseTable);
-  var levelSelected = $(".table-wrapper " + level.selector).not(baseTable);
+  var ruleSelected = $(rule, ".table-wrapper").not(baseTable);
+  var levelSelected = $(level.selector, ".table-wrapper").not(baseTable);
 
   var win = false;
 


### PR DESCRIPTION
Use the jQuery `context` argument to limit the scope of the selector.

The rule was previously checked by prepending `.table-wrapper`. When you have a comma-grouped selector `A, B`, this will result in:

``` css
.table-wrapper A, B
```

It selects any `B`, even ones outside of `.table-wrapper`. **This bug shows up in the :last-of-type level**, if you use the following selector:

``` css
orange:last-of-type, apple:last-of-type
```

Even though this (rather unoptimized) selector should work, it registered as a fail, because an innocent apple in the logo was also selected. To that apple's credit, it joined the party and _shook like there's no tomorrow_.
