### PR TITLE
CSS typo that fixes CSS Editor and HTML Viewer layout in IE11

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 * {
-  box-sixing: border-box;
+  box-sizing: border-box;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
 }


### PR DESCRIPTION
Loading this up in IE11 I noticed the CSS and HTML windows were on top of each other. I checked the CSS I saw the typo for box-sizing.
