### PR TITLE
Fixed fancy plate markup

### DIFF
--- a/restaurant.js
+++ b/restaurant.js
@@ -349,7 +349,7 @@ function loadBoard(){
     }
     if(c == "{") {
       boardMarkup = boardMarkup + '<plate id="fancy">'
-      markup = markup + '<div>&ltplate id="fancy"/&gt';
+      markup = markup + '<div>&ltplate id="fancy"&gt';
     }
     if(c == "(") {
       boardMarkup = boardMarkup + '<plate>'


### PR DESCRIPTION
The markup for fancy plates is invalid. For example, level 3:

```
<div class="table">
  <plate id="fancy"/></plate>
  <plate></plate>
  <bento></bento>
</div>
```

Deleting the extra slash should fix it. The only downside is you don't get a void element for an empty fancy plate (no `<plate id="fancy" />`).
