### PR TITLE
Show :first-child at bottom of stack

### DIFF
--- a/levels.js
+++ b/levels.js
@@ -187,7 +187,7 @@ var levels = [
   {
     selectorName: "First Child Pseudo-selector",
     helpTitle: "Select a first child element inside of another element",
-    doThis : "Select the top orange",
+    doThis : "Select the first orange on the plate",
     selector : "plate :first-child",
     syntax: ":first-child",
 
@@ -210,13 +210,13 @@ var levels = [
       '<strong>span:only-child</strong> selects the <strong>&lt;span&gt;</strong> elements that are the only child of some other element.',
       '<strong>ul li:only-child</strong> selects the only <strong>&lt;li&gt;</strong> element that are in a <strong>&lt;ul&gt;</strong>.'
     ],
-    board: "(A)(p)[]P(oO)p"
+    board: "(A)(p)[]P(Oo)p"
   },
   {
     selectorName: "Last Child Pseudo-selector",
     helpTitle: "Select the last element inside of another element",
-    doThis : "Select the small apple and the pickle",
-    selector : ".small:last-child",
+    doThis : "Select the first and last orange on the table",
+    selector : "orange:last-child",
     syntax: ":last-child",
     help : "You can use this selector to select an element that is the last child element inside of another element. <br><br>Pro Tip &rarr; In cases where there is only one element, that element counts as the first-child, only-child and last-child!",
     examples : [
@@ -224,7 +224,7 @@ var levels = [
       '<strong>span:last-child</strong> selects all last-child <strong>&lt;span&gt;</strong> elements.',
       '<strong>ul li:last-child</strong> selects the last <strong>&lt;li&gt;</strong> elements inside of any <strong>&lt;ul&gt;</strong>.'
     ],
-    board: "{a)()(oO)p"
+    board: "{O)[](Oa)O"
   },
   {
     selectorName: "Nth Child Pseudo-selector",
@@ -262,7 +262,7 @@ var levels = [
     examples : [
       '<strong>span:first-of-type</strong> selects the first <strong>&lt;span&gt;</strong> in any element.'
     ],
-    board: "Aaaa(oO)"
+    board: "Aaaa(Oo)"
   },
   {
     selectorName: "Nth of Type Selector",
@@ -300,7 +300,7 @@ var levels = [
     examples : [
       '<strong>p span:only-of-type</strong> selects a <tag>span</tag> within any <tag>p</tag> if it is the only <tag>span</tag> in there.'
     ],
-    board: "(aA)(a)(p)"
+    board: "(Aa)(a)(p)"
   },
 
   {

--- a/style.css
+++ b/style.css
@@ -440,10 +440,10 @@ plate apple
   position: absolute;
 }
 
-plate > apple:last-child,
-plate > orange:last-child,
-bento > apple:last-child,
-bento > orange:last-child
+plate > apple:first-child,
+plate > orange:first-child,
+bento > apple:first-child,
+bento > orange:first-child
 {
   top: calc(50% - 35px);
 }
@@ -729,26 +729,26 @@ plate orange {
   position: absolute;
 }
 
-plate apple:last-child,
-plate orange:last-child {
+plate apple:first-child,
+plate orange:first-child {
   z-index: 300;
 }
 
-plate apple:nth-last-child(2),
-plate orange:nth-last-child(2) {
+plate apple:nth-child(2),
+plate orange:nth-child(2) {
   top: -25px;
   z-index: 400;
 }
 
-plate apple:nth-last-child(3),
-plate orange:nth-last-child(3)
+plate apple:nth-child(3),
+plate orange:nth-child(3)
 {
   top: -65px;
   z-index: 500;
 }
 
-plate apple:nth-last-child(4),
-plate orange:nth-last-child(4)
+plate apple:nth-child(4),
+plate orange:nth-child(4)
 {
   top: -105px;
   z-index: 600;


### PR DESCRIPTION
In the real world, the first item added to a stack would reside at the
bottom of the stack. However, before these changes, the first item added
to a stack (in the markup) was shown at the top of the stack. This made
level "Select the top orange" somewhat confusing.

These changes reverse the presentation, such that the first item added
to a stack is shown at the bottom of the stack.

The level "Select the small apple and the pickle" was rewritten to
account for this. Before these changes, the solution .small:last-child
would have been acceptable because the small orange at the top of the
stack was not considered to be the last item. Now that the item at the
top of the stack is considered to be the last item, the arrangement
would not have worked. Swapping the oranges also made little sense,
since a large orange would not normally rest on top of a small orange.
The foods were changed altogether, and a bento was added to keep things
visually interesting (otherwise it would have been nothing but plates,
oranges, and apples).
