### PR TITLE
remove table tooltips when the game is over

### DIFF
--- a/restaurant.js
+++ b/restaurant.js
@@ -210,6 +210,10 @@ function resetTable(){
     $(this).width($(this).width());
     $(this).removeAttr("style");
   });
+  
+  // remove on mouseover event
+  $(".table").off("mouseover");
+  
   $(".table-edge").width($(".table").outerWidth());
 }
 


### PR DESCRIPTION
I added few lines to remove the tooltip support on $(".table") element when the game is over. 
