### PR TITLE
Added attribute selectors, and a few other changes...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.log

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,7 +1,55 @@
-##Where I left off
+** QA b4 Launch **
+  * Check to make sure all levels work
+  * Check that examples are correct
+
+  * QA the reset - it's wiggin out yo
+
+**Possible Level updates?**
+
+* selector: "plate:nth-of-type(2n+3)"
+  * Make this level use apples instead of plates? Seems too big..
+
+**Next update**
+
+* Email signup better twitter engagement?
+* Visual enhancements
+
+
+**Ideas & Future**
+
+* Tip jar / buy me a beer
+* Riddle of the day / week - that would be cool <- gives people a reason for engagement too,
+* Return customers so to speak.
+* Could be dope
+
+**Final Attrib Rules**
+* has attribute
+* attribute value = something
+* attribute starts with
+* attribute ends with
+
+**Maybes & Neat-o Improvements **
+
+* css line 591 - highlight border to match the element color?
+  * Commented out for now, but shoudl add again?
+  * I can make them specific to the situation so they always show up nicely
+
+**Attribute types I haven't used**
+
+[attr~=value]
+value is a whitespace-separated list of words, one of which is exactly "value".
+
+[attr|=value]
+Represents an element with an attribute name of attr. Its value can be exactly “value” or can begin with “value” immediately followed by “-” (U+002D). It can be used for language subcode matches.
+
+[attr~=value]
+Represents an element with an attribute name of attr whose value is a whitespace-separated list of words, one of which is exactly "value".
+
 
 **TO-DO**
 
+* Pull jquery from CDN?
+* Refactor
 * Figure out CNAME setup for github
   * Would be cool for it to always show up as cssdiner.com
 * Figure out next steps to increase reach and use
@@ -23,6 +71,22 @@ What kind of new content could I have?
 * Create a challenge mode?
 * Sandbox mode
 * New levels
+
+**Attribute selectors**
+
+* has attribute [for]
+* has an attribute with exact value
+  * ``[for=bob]``
+* has an attribute that starts with
+  * ``[for^=bob]``
+* has an attribute that contains
+  * ``[for*=bob]``
+* has an attribute that ends with
+  * ``[for$=bob]``
+* has this value in a list of space-separated attributes ``for="bob mary"``
+  * ``[for~=bob]``
+* has this value in a list of dash separated attributes ``for="bob-mary"``
+  * ``[for~=bob]``
 
 
 ####Figuring out hard levels

--- a/css/style.css
+++ b/css/style.css
@@ -82,6 +82,7 @@ header {
   position: absolute;
   top: 12px;
   left: 10px;
+  color: rgba(255,255,255,.4);
 }
 
 .logo plate {
@@ -96,46 +97,58 @@ header {
 
 .logo:hover plate {
   opacity: .75;
+  transform-origin: bottom;
+  animation: strobeStart .5s ease-out, strobe 1s infinite;
+  animation-delay: 0s, .5s;
+
 }
 
 .table-wrapper {
   margin-top: 10px;
-  -webkit-transform: rotateX(20deg) translate3d(0,0,0);
-  transform: rotateX(20deg) translate3d(0,0,0);
+  transform: rotateX(20deg);
   min-height: 142px;
-  -webkit-transform-origin: bottom;
   transform-origin: bottom;
-  -transform-style: preserve-3d;
+  z-index: 9999;
+  position: relative;
+  margin: 10px auto 0 auto;
+  width: 250px;
 }
 
 .table {
-  box-shadow: 0px 40px 10px rgba(0,0,0,.2);
-  -moz-box-shadow: 0px 40px 10px rgba(0,0,0,.2);
-  -webkit-transform-style: preserve-3d;
   transform-style: preserve-3d;
   outline: solid 1px transparent;
   margin: 0px auto 0px auto;
-  background: #DDD;
   min-height: 142px;
   padding: 15px 15px 22px 15px;
   display: inline-block;
-  background: #dd992d;
-  background: -webkit-linear-gradient(#dd992d,#cd8c26);
   z-index: 999;
   position:relative;
+  white-space: nowrap;
+}
+
+.table-surface {
+  box-shadow: 0px 40px 10px rgba(0,0,0,.2);
+  background: #dd992d;
+  background: -webkit-linear-gradient(#dd992d,#cd8c26);
+  background: linear-gradient(#dd992d,#cd8c26);
+  position: absolute;
+  height: 100%;
+  bottom: 0;
+  width: 100%;
+}
+
+.table plate {
+  z-index: 99999;
 }
 
 .table-edge  {
-  outline: solid 1px transparent;
-  display: none;
-  display: block;
-  margin:0 auto 10px auto;
+  width: 250px;
+  margin: 0 auto 10px auto;
   background: #ac741c;
   height: 15px;
   transform: rotateX(-40deg);
-  -webkit-transform: rotateX(-40deg);
-  -webkit-transform-origin: top;
   transform-origin: top;
+  z-index: 2;
 }
 
 .table-leg {
@@ -154,25 +167,40 @@ header {
   right: 20px;
 }
 
-orange,apple,pickle,bento,plate{
-  -webkit-transition: all -webkit-transform ease-out .2s;
+orange, apple, pickle, bento, plate {
+  transition: transform ease-out .2s;
 }
+
+.pop {
+  animation: pop .2s;
+}
+
+@keyframes pop {
+  0% {
+    opacity: 0;
+    transform: scale(.3);
+    transform-origin: center;
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+
+
 
 .clean {
-  -webkit-animation: cleanme .2s 1;
-  -webkit-transform: translateY(-600px) rotate3d(0,0,0,0deg);
-  -moz-animation: cleanme .2s 1;
-  -moz-transform: translateY(-600px);
+  animation: cleanme .2s 1;
+  transform: translateY(-600px);
 }
 
-@-webkit-keyframes cleanme {
-  0% {   -webkit-transform: translateY(0px) rotate3d(0,0,0,0deg); }
-  100% { -webkit-transform: translateY(-600px) rotate3d(0,0,0,0deg);}
-}
-
-@-moz-keyframes cleanme {
-  0% {   transform: translateY(0px) rotate3d(1,0,0,0deg) ; }
-  100% { transform: translateY(-600px) rotate3d(1,0,0,0deg);}
+@keyframes cleanme {
+  0% {   transform: translateY(0px) rotate3d(0,0,0,0deg); }
+  100% { transform: translateY(-600px) rotate3d(0,0,0,0deg);}
 }
 
 bento, plate {
@@ -228,11 +256,10 @@ bento:before {
 .editor {
   position: relative;
   text-align: left;
-  width: 750px;
+  width: 90%;
   margin: 0 auto;
   border: solid 10px rgba(0,0,0,.35);
-  -webkit-border-radius: 10px;
-  border-radius: 10px;
+  border-radius: 4px;
   overflow: hidden;
 }
 
@@ -259,8 +286,8 @@ bento:before {
   padding: 10px 15px;
   background: rgba(0,0,0,.15);
   border-top: solid 1px rgba(255,255,255,.05);
-  border-bottom: solid 2px #222;
-  -webkit-border-radius: 2px 2px 0 0;
+  border-bottom: solid 1px rgba(255,255,255,.05);
+  border-radius: 2px 2px 0 0;
   color: rgba(255,255,255,.6);
 }
 
@@ -484,15 +511,7 @@ bento > pickle.small:only-child {
 }
 
 .shake {
-  -webkit-animation: shake .1s 5;
-  -moz-animation: shake .1s 5;
-}
-
-@-webkit-keyframes shake {
-  0%   { -webkit-transform: translateX(0); }
-  25% {  -webkit-transform: translateX(-5px); }
-  50% {  -webkit-transform: translateX(0); }
-  75% {  -webkit-transform: translateX(5px); }
+  animation: shake .1s 5;
 }
 
 @keyframes shake {
@@ -503,18 +522,21 @@ bento > pickle.small:only-child {
 }
 
 .strobe {
-  -webkit-animation: strobe 1s infinite;
-  -webkit-transform-origin: bottom;
   transform-origin: bottom;
-  animation: strobe 1s infinite;
+  animation: strobeStart .5s ease-out, strobe 1s infinite;
+  animation-delay: 0s, .5s;
 }
 
-@-webkit-keyframes strobe {
-    0% { -webkit-transform:   skew(4deg,0deg) scaleX(1); }
-    10% { -webkit-transform:  skew(1deg,0deg) scaleY(.9) ; }
-    50% { -webkit-transform:  skew(-4deg,0deg) scaleX(1); }
-    60% { -webkit-transform:  skew(-1deg,0deg) scaleY(.9) ; }
-    100% { -webkit-transform: skew(4deg,0deg) scaleX(1); }
+@keyframes strobeStart {
+  0% {
+    transform:  skew(0deg,0deg) scaleY(1) ;
+    animation-timing-function: ease-in;
+   }
+  40% {
+    transform:  skew(0deg,0deg) scaleY(.9);
+    animation-timing-function: ease-out;
+  }
+  100% { transform:   skew(4deg,0deg) scaleX(1); }
 }
 
 @keyframes strobe {
@@ -524,6 +546,7 @@ bento > pickle.small:only-child {
   60% { transform:  skew(-1deg,0deg) scaleY(.9) ; }
   100% {transform: skew(4deg,0deg) scaleX(1); }
 }
+
 
 .enter-button {
   background: #ddd;
@@ -569,14 +592,19 @@ bento > pickle.small:only-child {
   display: none;
 }
 
-[data-hovered="true"] {
+[data-hovered] {
   box-shadow: 0 0 0 6px rgba(255,255,255,.4);
 }
 
-
-plate [data-hovered="true"] {
+plate [data-hovered] {
   box-shadow: 0 0 0 6px rgba(0,0,0,.3);
 }
+
+/*
+apple[data-hovered="true"] {
+  box-shadow: 0 0 0 6px rgba(228,25,25,.3);
+}
+*/
 
 .helper {
   position: absolute;
@@ -591,7 +619,7 @@ plate [data-hovered="true"] {
   transform: rotateX(20deg);
   outline: solid 1px transparent;
   word-wrap: nowrap;
-
+  white-space: nowrap;
 }
 
 plate:before {
@@ -649,7 +677,7 @@ orange {
   padding: 0;
   font-weight: 200;
   opacity: .8;
-  margin-bottom: 25px;
+  margin-bottom: 18px;
   background: rgba(255,255,255,.05);
   display: inline-block;
   padding: 5px 8px;
@@ -661,6 +689,11 @@ orange {
   line-height: 150%;
 }
 
+.display-help .examples-title {
+  margin: 45px 0 10px 0;
+  padding: 0;
+}
+
 .display-help .hint,
 .display-help .example {
   color: #888;
@@ -668,7 +701,7 @@ orange {
 }
 
 .display-help .example {
-  border-bottom: solid 1px rgba(255,255,255,.05);
+  border-bottom: solid 1px rgba(255,255,255,.1);
   padding: 10px 0 12px 0;
   line-height: 170%;
 }
@@ -685,6 +718,7 @@ orange {
   margin: 0px 2px;
   font-size: 13px;
   font-family: menlo,monospace;
+  font-weight: normal;
 }
 
 .display-help .example strong:first-of-type {
@@ -804,7 +838,7 @@ plate orange:nth-last-child(4)
 .level-header .checkmark {
   position: relative;
   display: inline-block;
-  margin-left: 15px;
+  margin-left: 8px;
   width: 12px;
   height: 20px;
   opacity: 2;
@@ -902,11 +936,12 @@ plate orange:nth-last-child(4)
 .left-col {
   width: calc(100% - 375px);
   text-align: center;
-  overflow: hidden;
+  overflow-x: visible;
   position: fixed;
   top: 0;
   bottom: 0;
   left: 0;
+  z-index: 2;
 }
 
 /**::-webkit-scrollbar { width: 0 !important }*/
@@ -915,11 +950,12 @@ plate orange:nth-last-child(4)
   position: fixed;
   width: 375px;
   right: 0;
-  overflow: auto;
+/*  overflow: auto;*/
   top: 40px;
   top: 0;
   bottom: 0;
   background: #221e18;
+  z-index: 1;
 }
 
 .level-menu {
@@ -940,7 +976,7 @@ plate orange:nth-last-child(4)
 }
 
 .levels {
-  margin-bottom: 150px;
+  padding-bottom: 150px;
 }
 
 .level-menu h2 {
@@ -962,7 +998,7 @@ plate orange:nth-last-child(4)
   background: rgba(0,0,0,.2);
 }
 
-.level-menu a {
+.level-menu .levels a {
   display: block;
   cursor: pointer;
   padding: 5px 12px 5px 22px;
@@ -974,13 +1010,13 @@ plate orange:nth-last-child(4)
   display: inline-block;
 }
 
-.level-menu a.completed .checkmark {
+.level-menu .levels a.completed .checkmark {
   opacity: .55;
   border: solid 3px #4cbb4a;
   border-width: 0 3px 3px 0;
 }
 
-.level-menu a .checkmark {
+.level-menu .levels a .checkmark {
   position: relative;
   display: inline-block;
   margin-right: 14px;
@@ -994,20 +1030,15 @@ plate orange:nth-last-child(4)
   transform: rotate(40deg);
 }
 
-.level-menu a:hover {
-  color: #999;
-}
-
-.level-menu a.current {
+.level-menu .levels a.current {
   font-weight: bold;
   color: #AAA;
   background: rgba(255,255,255,.07);
 }
 
-.level-menu a:hover {
+.level-menu .levels a:hover {
   background: rgba(255,255,255,.05);
 }
-
 
 .level-menu .level-number {
   opacity: .6;
@@ -1017,12 +1048,11 @@ plate orange:nth-last-child(4)
 
 .level-menu-toggle-wrapper {
   position: absolute;
-  top: 22px;
+  top: 20px;
   right: 20px;
   height: 30px;
   padding: 4px 2px;
   opacity: .25;
-  -webkit-transition: linear all .05s;
   transition: linear all .05s;
   cursor: pointer;
 }
@@ -1130,6 +1160,8 @@ plate orange:nth-last-child(4)
   padding: 0;
 }
 
+/* Winner screen */
+
 .winner {
   font-size: 30px;
   color: #EEE;
@@ -1143,12 +1175,71 @@ plate orange:nth-last-child(4)
   font-size: 40px;
 }
 
+
+/* Previous and next level navigation */
+
 .level-nav {
-  float: right;
-  position: relative;
-  left: -150px;
-  display: none;
+  position: absolute;
+  right: 60px;
+  top: 20px;
+  line-height: 0;
 }
+
+.level-nav a {
+  padding: 5px;
+  position: relative;
+  height: 30px;
+  width: 30px;
+  display: inline-block;
+  opacity: .25;
+  transition: opacity .2s .ease-out;
+}
+
+.level-nav a:hover {
+  opacity: .4;
+}
+
+.level-nav a:after {
+  content: "";
+  height: 18px;
+  width: 18px;
+  position: absolute;
+  border: solid 2px white;
+  border-width: 2px 2px 0 0;
+  transform-origin: center center;
+  top: 6px;
+  box-sizing: border-box;
+}
+
+.level-nav .previous:after {
+  transform: rotate(-135deg);
+  right: 2px;
+}
+
+.level-nav .next:after {
+  transform: rotate(45deg);
+  left: 2px;
+}
+
+.level-nav a.link-jiggle {
+  animation: linkJiggle .2s ease-out;
+}
+
+@keyframes linkJiggle {
+  0% {
+    transform: scale(1);
+  }
+  10% {
+    transform: scaleX(.87) scaleY(.8);
+
+  }
+  40% {
+    transform: scale(1.13);
+  }
+
+}
+
+/* Tag treatment for the level helpers & examples */
 
 tag {
   padding: 0 3px;
@@ -1165,33 +1256,86 @@ tag:after {
   content: ">";
 }
 
-/*::-webkit-scrollbar {
-  width: 8px;
-  display: none;
+.nametags {
+  z-index: 1;
+  width: 100%;
+  position: absolute;
+  bottom: 0;
 }
 
-::-webkit-scrollbar-track {
+.nametag {
+  font-family: "Satisfy", sans-serif;
+  position: absolute;
+  bottom: -14px;
+  color: black;
+  width: 80px;
+  color: #09699b;
+  font-size: 22px;
+  box-shadow: -3px 4px 0 rgba(0,0,0,.1);
+  background-image: url(../images/line.png);
+  z-index: 9999;
+  padding: 30px 0 2px 0 ;
+  background-color: #c5d6dd;
+  transform: rotate(-4deg);
+  animation: slide .4s ease-out;
 }
 
-::-webkit-scrollbar-thumb {
-  background: rgba(255,255,255,.15);
-  border-radius: 10px;
-}*/
+@keyframes slide {
+  0% {
+    transform: translateY(-20px);
+    animation-timing-function: ease-out;
+  }
+  50% {
+    transform: translateY(2px) rotate(-4deg);
+    animation-timing-function: ease-in;
+  }
+  100% {
+    transform: translateY(0px) rotate(-4deg);
+  }
+}
 
+/*Overrides for the custom scrollbar plugin*/
 
 .mCSB_scrollTools .mCSB_dragger .mCSB_dragger_bar{
-	background-color: #fff; background-color: rgba(255,255,255,0.15);
-	filter: "alpha(opacity=75)"; -ms-filter: "alpha(opacity=75)";
+  background-color: #fff; background-color: rgba(255,255,255,0.15);
+  filter: "alpha(opacity=75)"; -ms-filter: "alpha(opacity=75)";
 }
 
 .mCSB_scrollTools .mCSB_dragger:hover .mCSB_dragger_bar{
-	background-color: #fff; background-color: rgba(255,255,255,0.3);
-	filter: "alpha(opacity=85)"; -ms-filter: "alpha(opacity=85)";
+  background-color: #fff; background-color: rgba(255,255,255,0.3);
+  filter: "alpha(opacity=85)"; -ms-filter: "alpha(opacity=85)";
 }
 .mCSB_scrollTools .mCSB_dragger:active .mCSB_dragger_bar,
 .mCSB_scrollTools .mCSB_dragger.mCSB_dragger_onDrag .mCSB_dragger_bar{
-	background-color: #fff; background-color: rgba(255,255,255,.3);
-	filter: "alpha(opacity=90)"; -ms-filter: "alpha(opacity=90)";
+  background-color: #fff; background-color: rgba(255,255,255,.3);
+  filter: "alpha(opacity=90)"; -ms-filter: "alpha(opacity=90)";
 }
 
 .mCSB_inside > .mCSB_container{ margin-right: 0; }
+
+.mCustomScrollBox {
+ overflow: visible !important;
+}
+
+.mCSB_container {
+  overflow: visible !important;
+}
+
+
+.reset-progress {
+  display: block;
+  text-align: center;
+  text-decoration: none;
+  position: relative;
+  top: -20px;
+  border: solid 2px rgba(255,255,255,.2);
+  box-sizing: border-box;
+  width: calc(100% - 40px);
+  color: rgba(255,255,255,.4);
+  margin:  0 auto;
+  padding: 9px 0 11px 0;
+}
+
+.reset-progress:hover {
+  background: rgba(255,255,255,.05);
+}

--- a/index.html
+++ b/index.html
@@ -8,15 +8,16 @@
     <script src="js/jquery.mCustomScrollbar.min.js"></script>
 
     <link rel="icon" type="image/png" href="favicon.png">
-    <link href='https://fonts.googleapis.com/css?family=Exo+2:200,400,600,400italic,600italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Exo+2:200,400,600,400italic,600italic' rel='stylesheet'>
+    <link href="https://fonts.googleapis.com/css?family=Satisfy" rel="stylesheet">
     <link rel="stylesheet" href="css/jquery.mCustomScrollbar.css" type="text/css" media="screen" title="no title" charset="utf-8">
     <link rel="stylesheet" href="css/style.css" type="text/css" media="screen" title="no title" charset="utf-8">
 
     <meta property="og:url"           content="http://cssdiner.com" />
-  	<meta property="og:type"          content="website" />
-  	<meta property="og:title"         content="CSS Diner" />
-  	<meta property="og:description"   content="A fun game to help you learn and practice CSS selectors." />
-  	<meta property="og:image"         content="https://flukeout.github.io/images/fb-share.jpg" />
+    <meta property="og:type"          content="website" />
+    <meta property="og:title"         content="CSS Diner" />
+    <meta property="og:description"   content="A fun game to help you learn and practice CSS selectors." />
+    <meta property="og:image"         content="https://flukeout.github.io/images/fb-share.jpg" />
   </head>
 
   <body>
@@ -51,10 +52,18 @@ p {
    margin-bottom: 12px;
 }</pre>
 
-        <p>Here, the "p" is the selector (selects all &lt;p&gt; elements) and applies the margin-bottom style.</p>
-        <p>To play, type in a CSS selector in the editor below to select the correct items on the table.If you get it right, you'll advance to the next level.</p>
-        <p>Hover over the items on the table to see their HTML markup.</p>
-        <p>Get help with selectors on the right! &rarr;</p>
+        <p>
+          Here, the "p" is the selector (selects all &lt;p&gt; elements) and applies the margin-bottom style.
+        </p>
+        <p>
+          To play, type in a CSS selector in the editor below to select the correct items on the table.If you get it right, you'll advance to the next level.
+        </p>
+        <p>
+          Hover over the items on the table to see their HTML markup.
+        </p>
+        <p>
+          Get help with selectors on the right! &rarr;
+        </p>
         <a class="note-toggle" href="#">Ok, got it!</a>
       </div>
 
@@ -62,6 +71,8 @@ p {
 
       <div class="game-wrapper">
         <div class="table-wrapper">
+          <div class="table-surface"></div>
+          <div class="nametags"></div>
           <div class="table"></div>
         </div>
         <div class="table-edge">
@@ -94,6 +105,7 @@ p {
             </div>
           </div>
         </div>
+
         <div class="editor-pane html-view">
           <div class="input-header">
             <div class="file-name">table.html</div>
@@ -107,11 +119,15 @@ p {
       </div>
 
       <div class="what-is-this">
-        <p>Made by <a href="http://www.twitter.com/flukeout">@flukeout</a> &mdash; come say hi!</p>
-        <p>Have feedback? Please file an isssue on <a href="https://github.com/flukeout/css-diner/issues">the Github repo</a>.</p>
+        <p>
+          Made by <a href="http://www.twitter.com/flukeout">@flukeout</a> &mdash; come say hi!
+        </p>
+        <p>
+          Have feedback or questions? Please file an isssue on <a href="https://github.com/flukeout/css-diner/issues">the Github repo</a>.
+        </p>
       </div>
 
-      <div class="helper"></div><!-- This is the popup that floats over table elements -->
+      <div class="helper"><!-- This is the popup that floats over table elements --></div>
 
     </div><!-- /left col -->
 
@@ -119,8 +135,8 @@ p {
 
       <div class="help-wrapper">
         <div class="level-nav">
-          <a href="#">&lt;</a>
-          <a href="#">&gt;</a>
+          <a class="previous" href="#"></a>
+          <a class="next" href="#"></a>
         </div>
         <h1 class="level-header">
           <span class="level-text"></span>
@@ -131,17 +147,19 @@ p {
 
           <h3 class="selector-name"></h3>
           <h2 class="title"></h2>
-          <h3 class="syntax"></h3>
 
+          <h3 class="syntax"></h3>
           <div class="hint"></div>
+          <h4 class="examples-title">Examples</h4>
           <div class="examples"></div>
-          <div class="selector"></div>
+
         </div>
       </div>
 
       <div class="level-menu">
         <h2>Choose a level</h2>
         <div class="levels"></div>
+        <a class="reset-progress" href="#">Reset Progress</a>
       </div>
 
       <div class="level-menu-toggle-wrapper">

--- a/js/levels.js
+++ b/js/levels.js
@@ -1,20 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-
-// Hash the array and compare the arrays!
-// Key
-// a = small apple .small
-// A = apple
-// o = small orange, .small
-// O = orange
-// p = small pickle, .small
-// P = pickle
-// () = plate open / close
-// {} = fancy plate open / close
-// [] = bento open close tags
-
 var levels = [
   {
     helpTitle : "Select elements by their type",
@@ -24,10 +7,13 @@ var levels = [
     syntax : "A",
     help : "Selects all elements of type <strong>A</strong>. Type refers to the type of tag, so <tag>div</tag>, <tag>p</tag> and <tag>ul</tag> are all different element types.",
     examples : [
-      '<strong>div</strong> selects all <tag>div</tag> elements.',
-      '<strong>p</strong> selects all <tag>p</tag> elements.',
-      ],
-    board: "()()"
+      '<strong>div</strong> will select all <tag>div</tag> elements.',
+      '<strong>p</strong> will select all <tag>p</tag> elements.',
+    ],
+    boardMarkup: `
+    <plate/>
+    <plate/>
+    `
   },
   {
     doThis : "Select the bento boxes",
@@ -39,8 +25,12 @@ var levels = [
     examples : [
       '<strong>div</strong> will select all <tag>div</tag> elements.',
       '<strong>p</strong> will select all <tag>p</tag> elements.',
-      ],
-    board: "[]()[]"
+    ],
+    boardMarkup: `
+    <bento/>
+    <plate/>
+    <bento/>
+    `
   },
   {
     doThis : "Select the fancy plate",
@@ -48,12 +38,16 @@ var levels = [
     selectorName: "ID Selector",
     helpTitle: "Select elements with an ID",
     syntax: "#id",
-    help : 'Selects the element with the <strong>id</strong> attribute. You can also combine the ID selector with the type selector.',
+    help : 'Selects the element with a specific <strong>id</strong>. You can also combine the ID selector with the type selector.',
     examples : [
       '<strong>#cool</strong> will select any element with <strong>id="cool"</strong>',
-      '<strong>ul#long</strong> will select <strong>&lt;ul id="long"&gt;</strong>'
+      '<strong>ul#long</strong> will select <tag>ul id="long"</tag>'
     ],
-    board: "{}()[]"
+    boardMarkup : `
+    <plate id="fancy"/>
+    <plate/>
+    <bento/>
+    `
   },
   {
     helpTitle: "Select an element inside another element",
@@ -61,13 +55,18 @@ var levels = [
     doThis : "Select the apple on the plate",
     selector : "plate apple",
     syntax: "A&nbsp;&nbsp;B",
-
-    help : "Selects all <strong>B</strong> inside of <strong>A</strong>. Here <strong>B</strong> is the descendant element, meaning an element that is inside of another element.",
+    help : "Selects all <strong>B</strong> inside of <strong>A</strong>. <strong>B</strong> is called a descendant because it is inside of another element.",
     examples : [
-      '<strong>p&nbsp;&nbsp;strong</strong> will select all <strong>&lt;strong&gt;</strong> that are descendants of any <strong>&lt;p&gt;</strong>',
-      '<strong>#fancy&nbsp;&nbsp;span</strong> will select any <strong>&lt;span&gt;</strong> that is a descendant of any element with  <strong>id="fancy"</strong>',
+      '<strong>p&nbsp;&nbsp;strong</strong> will select all <tag>strong</tag> elements that are inside of any <tag>p</tag>',
+      '<strong>#fancy&nbsp;&nbsp;span</strong> will select any <tag>span</tag> elements that are inside of the element with <strong>id="fancy"</strong>',
     ],
-    board: "[](A)A"
+    boardMarkup : `
+    <bento/>
+    <plate>
+      <apple/>
+    </plate>
+    <apple/>
+    `
   },
   {
     doThis : "Select the pickle on the fancy plate",
@@ -76,23 +75,38 @@ var levels = [
     syntax: "#id&nbsp;&nbsp;A",
     help : 'You can combine any selector with the descendent selector.',
     examples : [
-      '<strong>#cool&nbsp;span</strong> will select all <strong>&lt;span&gt;</strong> elements that are inside of elements with <strong>id="cool"</strong>'
+      '<strong>#cool&nbsp;span</strong> will select all <tag>span</tag> elements that are inside of elements with <strong>id="cool"</strong>'
     ],
-    board: "[O]{P}(P)"
+    boardMarkup : `
+    <bento>
+    <orange/>
+    </bento>
+    <plate id="fancy">
+      <pickle/>
+    </plate>
+    <plate>
+      <pickle/>
+    </plate>
+    `
   },
   {
     doThis : "Select the small apples",
     selector : ".small",
     selectorName: "Class Selector",
     helpTitle: "Select elements by their class",
-
     syntax: ".classname",
     help : 'The class selector selects all elements with that class attribute. Elements can only have one ID, but many classes.',
     examples : [
     '<strong>.neato</strong> selects all elements with <strong>class="neato"</strong>'
     ],
-
-    board: "Aa(a)()"
+    boardMarkup : `
+    <apple/>
+    <apple class="small"/>
+    <plate>
+      <apple class="small"/>
+    </plate>
+    <plate/>
+    `
   },
   {
     doThis : "Select the small oranges",
@@ -101,10 +115,21 @@ var levels = [
     syntax: "A.className",
     help : 'You can combine the class selector with other selectors, like the type selector.',
     examples : [
-      '<strong>ul.important</strong> will select all <strong>&lt;ul&gt;</strong> elements that have <strong>class="important"</strong>',
+      '<strong>ul.important</strong> will select all <tag>ul</tag> elements that have <strong>class="important"</strong>',
       '<strong>#big.wide</strong> will select all elements with <strong>id="big"</strong> that also have <strong>class="wide"</strong>'
     ],
-    board: "Aa[o](O)(o)"
+    boardMarkup :`
+    <apple/>
+    <apple class="small"/>
+    <bento>
+      <orange class="small"/>
+    </bento>
+    <plate>
+      <orange/>
+    </plate>
+    <plate>
+      <orange class="small"/>
+    </plate>`
   },
   {
     doThis : "Select the small oranges in the bentos",
@@ -112,11 +137,24 @@ var levels = [
     syntax: "Put your back into it!",
     helpTitle: "You can do it...",
     help : 'Combine what you learned in the last few levels to solve this one!',
-    board: "A(o)[o][a][o]"
+    boardMarkup : `
+    <bento>
+      <orange/>
+    </bento>
+    <orange class="small"/>
+    <bento>
+      <orange class="small"/>
+    </bento>
+    <bento>
+      <apple class="small"/>
+    </bento>
+    <bento>
+      <orange class="small"/>
+    </bento>
+    `
   },
   {
     doThis : "Select all the plates and bentos",
-
     selector : "plate,bento",
     selectorName : "Comma Combinator",
     helpTitle: "Combine, selectors, with... commas!",
@@ -126,7 +164,21 @@ var levels = [
     '<strong>p, .fun</strong> will select all <tag>p</tag> elements as well as all elements with <strong>class="fun"</strong>',
     '<strong>a, p, div</strong> will select all <tag>a</tag>, <tag>p</tag> and <tag>div</tag> elements'
     ],
-    board: "pP(P)[P](P)Pp"
+    boardMarkup : `
+    <pickle class="small"/>
+    <pickle/>
+    <plate>
+      <pickle/>
+    </plate>
+    <bento>
+      <pickle/>
+    </bento>
+    <plate>
+      <pickle/>
+    </plate>
+    <pickle/>
+    <pickle class="small"/>
+    `
   },
   {
     doThis : "Select all the things!",
@@ -136,9 +188,19 @@ var levels = [
     syntax : "*",
     help : 'You can select all elements with the universal selector! ',
     examples : [
-      '<strong>p *</strong> will select every element inside all <strong>&lt;p&gt;</strong> elements.'
+      '<strong>p *</strong> will select any element inside all <tag>p</tag> elements.',
     ],
-    board: "A(o)[][O]{)"
+    boardMarkup : `
+    <apple/>
+    <plate>
+      <orange class="small" />
+    </plate>
+    <bento/>
+    <bento>
+      <orange/>
+    </bento>
+    <plate id="fancy"/>
+    `
   },
   {
     doThis : "Select everything on a plate",
@@ -147,10 +209,20 @@ var levels = [
     helpTitle: "Combine the Universal Selector",
     help : 'This will select all elements inside of <strong>A</strong>.',
     examples : [
-      '<strong>p *</strong> will select every element inside all <strong>&lt;p&gt;</strong> elements.',
-      '<strong>ul.fancy *</strong> will select every element inside all <strong>&lt;ul class="fancy"&gt;</strong> elements.'
+      '<strong>p *</strong> will select every element inside all <tag>p</tag> elements.',
+      '<strong>ul.fancy *</strong> will select every element inside all <tag>ul class="fancy"</tag> elements.'
     ],
-    board: "{o}(P)a(A)"
+    boardMarkup: `
+    <plate id="fancy">
+      <orange class="small"/>
+    </plate>
+    <plate>
+      <pickle/>
+    </plate>
+    <apple class="small"/>
+    <plate>
+      <apple/>
+    </plate>`
   },
   {
     doThis : "Select every apple that's next to a plate",
@@ -163,7 +235,17 @@ var levels = [
       '<strong>p + .intro</strong> will select every element with <strong>class="intro"</strong> that directly follows a <tag>p</tag>',
       '<strong>div + a</strong> will select every <tag>a</tag> element that directly follows a <tag>div</tag>'
     ],
-    board: "[a]()a()Aaa"
+    boardMarkup : `
+    <bento>
+      <apple class="small"/>
+    </bento>
+    <plate />
+    <apple class="small"/>
+    <plate />
+    <apple/>
+    <apple class="small"/>
+    <apple class="small"/>
+    `
   },
   {
     selectorName: "General Sibling Selector",
@@ -175,7 +257,20 @@ var levels = [
     examples : [
       '<strong>A ~ B</strong> will select all <strong>B</strong> that follow a <strong>A</strong>'
     ],
-    board: "P[o]pP(P)(p)"
+    boardMarkup : `
+    <pickle/>
+    <bento>
+      <orange class="small"/>
+    </bento>
+    <pickle class="small"/>
+    <pickle/>
+    <plate>
+      <pickle/>
+    </plate>
+    <plate>
+      <pickle class="small"/>
+    </plate>
+    `
   },
   {
     selectorName: "Child Selector",
@@ -187,7 +282,19 @@ var levels = [
     examples : [
       '<strong>A > B</strong> will select all <strong>B</strong> that are a direct children <strong>A</strong>'
     ],
-    board: "([A])(A)()Aa"
+    boardMarkup: `
+    <plate>
+      <bento>
+        <apple/>
+      </bento>
+    </plate>
+    <plate>
+      <apple/>
+    </plate>
+    <plate/>
+    <apple/>
+    <apple class="small"/>
+    `
   },
   {
     selectorName: "First Child Pseudo-selector",
@@ -199,10 +306,19 @@ var levels = [
     help : "You can select the first child element. A child element is any element that is directly nested in another element. You can combine this pseudo-selector with other selectors.",
     examples : [
       '<strong>:first-child</strong> selects all first child elements.',
-      '<strong>p:first-child</strong> selects all first child <strong>&lt;p&gt;</strong> elements.',
-      '<strong>div p:first-child</strong> selects all first child <strong>&lt;p&gt;</strong> elements that are in a <strong>&lt;div&gt;</strong>.'
+      '<strong>p:first-child</strong> selects all first child <tag>p</tag> elements.',
+      '<strong>div p:first-child</strong> selects all first child <tag>p</tag> elements that are in a <tag>div</tag>.'
     ],
-    board: "[]()(OOO)p"
+    boardMarkup :`
+    <bento/>
+    <plate />
+    <plate>
+      <orange />
+      <orange />
+      <orange />
+    </plate>
+    <pickle class="small" />
+    `
   },
   {
     selectorName: "Only Child Pseudo-selector",
@@ -212,10 +328,25 @@ var levels = [
     syntax: ":only-child",
     help : "You can select any element that is the only element inside of another one.",
     examples : [
-      '<strong>span:only-child</strong> selects the <strong>&lt;span&gt;</strong> elements that are the only child of some other element.',
-      '<strong>ul li:only-child</strong> selects the only <strong>&lt;li&gt;</strong> element that are in a <strong>&lt;ul&gt;</strong>.'
+      '<strong>span:only-child</strong> selects the <tag>span</tag> elements that are the only child of some other element.',
+      '<strong>ul li:only-child</strong> selects the only <tag>li</tag> element that are in a <tag>ul</tag>.'
     ],
-    board: "(A)(p)[]P(oO)p"
+    boardMarkup : `
+    <plate>
+      <apple/>
+    </plate>
+    <plate>
+      <pickle />
+    </plate>
+    <bento>
+      <pickle />
+    </bento>
+    <plate>
+      <orange class="small"/>
+      <orange/>
+    </plate>
+    <pickle class="small"/>
+    `
   },
   {
     selectorName: "Last Child Pseudo-selector",
@@ -226,10 +357,19 @@ var levels = [
     help : "You can use this selector to select an element that is the last child element inside of another element. <br><br>Pro Tip &rarr; In cases where there is only one element, that element counts as the first-child, only-child and last-child!",
     examples : [
       '<strong>:last-child</strong> selects all last-child elements.',
-      '<strong>span:last-child</strong> selects all last-child <strong>&lt;span&gt;</strong> elements.',
-      '<strong>ul li:last-child</strong> selects the last <strong>&lt;li&gt;</strong> elements inside of any <strong>&lt;ul&gt;</strong>.'
+      '<strong>span:last-child</strong> selects all last-child <tag>span</tag> elements.',
+      '<strong>ul li:last-child</strong> selects the last <tag>li</tag> elements inside of any <tag>ul</tag>.'
     ],
-    board: "{a)()(oO)p"
+    boardMarkup : `
+    <plate id="fancy">
+      <apple class="small"/>
+    </plate>
+    <plate/>
+    <plate>
+      <orange class="small"/>
+      <orange>
+    </plate>
+    <pickle class="small"/>`
   },
   {
     selectorName: "Nth Child Pseudo-selector",
@@ -237,13 +377,17 @@ var levels = [
     doThis : "Select the 3rd plate",
     selector : ":nth-child(3)",
     syntax: ":nth-child(A)",
-
     help : "Selects the <strong>nth</strong> (Ex: 1st, 3rd, 12th etc.) child element in another element.",
     examples : [
       '<strong>:nth-child(8)</strong> selects every element that is the 8th child of another element.',
       '<strong>div p:nth-child(2)</strong> selects the second <strong>p</strong> in every <strong>div</strong>',
     ],
-    board: "()()(){}"
+    boardMarkup : `
+    <plate/>
+    <plate/>
+    <plate/>
+    <plate id="fancy"/>
+    `
   },
   {
     selectorName: "Nth Last Child Selector",
@@ -255,7 +399,17 @@ var levels = [
     examples : [
       '<strong>:nth-last-child(2)</strong> selects all second-to-last child elements.'
     ],
-    board: "()[]a(OOO)[]"
+    boardMarkup: `
+    <plate/>
+    <bento/>
+    <apple class="small"/>
+    <plate>
+      <orange/>
+      <orange/>
+      <orange/>
+    </plate>
+    <bento/>
+    `
   },
   {
     selectorName: "First of Type Selector",
@@ -265,13 +419,22 @@ var levels = [
     syntax: ":first-of-type",
     help : "Selects the first element of that type within another element.",
     examples : [
-      '<strong>span:first-of-type</strong> selects the first <strong>&lt;span&gt;</strong> in any element.'
+      '<strong>span:first-of-type</strong> selects the first <tag>span</tag> in any element.'
     ],
-    board: "Aaaa(oO)"
+    boardMarkup: `
+    <orange class="small"/>
+    <apple/>
+    <apple class="small"/>
+    <apple/>
+    <apple class="small"/>
+    <plate>
+      <orange class="small"/>
+      <orange/>
+    </plate>
+    `
   },
   {
     selectorName: "Nth of Type Selector",
-    // helpTitle: "Nth of Type Selector",
     doThis: "Select all even plates",
     selector: "plate:nth-of-type(even)",
     syntax: ":nth-of-type(A)",
@@ -280,11 +443,17 @@ var levels = [
       '<strong>div:nth-of-type(2)</strong> selects the second instance of a div.',
       '<strong>.example:nth-of-type(odd)</strong> selects all odd instances of a the example class.'
     ],
-    board: "()()()(){}()"
+    boardMarkup : `
+    <plate/>
+    <plate/>
+    <plate/>
+    <plate/>
+    <plate id="fancy"/>
+    <plate/>
+    `
   },
   {
     selectorName: "Nth-of-type Selector with Formula",
-    // helpTitle: "Nth-of-type Selector with formula",
     doThis: "Select every 2nd plate, starting from the 3rd",
     selector: "plate:nth-of-type(2n+3)",
     syntax: ":nth-of-type(An+B)",
@@ -292,34 +461,63 @@ var levels = [
     examples: [
       '<strong>span:nth-of-type(6n+2)</strong> selects every 6th instance of a <tag>span</tag>, starting from (and including) the second instance.'
     ],
-    board: "()(p)(a)()(A)()"
+    boardMarkup : `
+    <plate/>
+    <plate>
+      <pickle class="small" />
+    </plate>
+    <plate>
+      <apple class="small" />
+    </plate>
+    <plate/>
+    <plate>
+      <apple />
+    </plate>
+    <plate/>
+    `
   },
-
   {
     selectorName: "Only of Type Selector",
     helpTitle: "Select elements that are the only ones of their type within of their parent element",
     selector : "apple:only-of-type",
     syntax: ":only-of-type",
-    doThis : "Select the apple on the middle plate.",
+    doThis : "Select the apple on the middle plate",
     help : "Selects the only element of its type within another element.",
     examples : [
       '<strong>p span:only-of-type</strong> selects a <tag>span</tag> within any <tag>p</tag> if it is the only <tag>span</tag> in there.'
     ],
-    board: "(aA)(a)(p)"
+    boardMarkup: `
+    <plate id="fancy">
+      <apple class="small" />
+      <apple />
+    </plate>
+    <plate>
+      <apple class="small" />
+    </plate>
+    <plate>
+      <pickle />
+    </plate>
+    `
   },
-
   {
     selectorName: "Last of Type Selector",
     helpTitle: "Select the last element of a specific type",
-    doThis : "Select the second apple and orange",
+    doThis : "Select the last apple and orange",
     selector : ".small:last-of-type",
     syntax: ":last-of-type",
     help : "Selects each last element of that type within another element. Remember type refers the kind of tag, so <tag>p</tag> and <tag>span</tag> are different types. <br><br> I wonder if this is how the last dinosaur was selected before it went extinct.",
     examples : [
-      '<strong>div:last-of-type</strong> selects the last <strong>&lt;div&gt;</strong> in every element.',
-      '<strong>p span:last-of-type</strong> selects the last <strong>&lt;span&gt;</strong> in every <strong>&lt;p&gt;</strong>.'
+      '<strong>div:last-of-type</strong> selects the last <tag>div</tag> in every element.',
+      '<strong>p span:last-of-type</strong> selects the last <tag>span</tag> in every <tag>p</tag>.'
     ],
-    board: "ooPPaa"
+    boardMarkup : `
+    <orange class="small"/>
+    <orange class="small" />
+    <pickle />
+    <pickle />
+    <apple class="small" />
+    <apple class="small" />
+    `
   },
   {
     selectorName: "Empty Selector",
@@ -329,14 +527,19 @@ var levels = [
     syntax: ":empty",
     help : "Selects elements that don't have any other elements inside of them.",
     examples : [
-      '<strong>div:empty</strong> selects all empty <strong>&lt;div&gt;</strong> elements.'
+      '<strong>div:empty</strong> selects all empty <tag>div</tag> elements.'
     ],
-    board: "[][p][][]"
+    boardMarkup:`
+    <bento/>
+    <bento>
+      <pickle class="small"/>
+    </bento>
+    <plate/>
+    <bento/>`
   },
   {
     selectorName: "Negation Pseudo-class",
     helpTitle: "Select all elements that don't match the negation selector",
-
     doThis : "Select the big apples",
     selector : "apple:not(.small)",
     syntax: ":not(X)",
@@ -346,6 +549,122 @@ var levels = [
       '<strong>div:not(:first-child)</strong> selects every <tag>div</tag> that is not a first child.',
       '<strong>:not(.big, .medium)</strong> selects all elements that do not have <strong>class="big"</strong> or <strong>class="medium"</strong>.'
     ],
-    board: "{a}(A)A(o)p"
+    boardMarkup: `
+    <plate id="fancy">
+      <apple class="small" />
+    </plate>
+    <plate>
+      <apple />
+    </plate>
+    <apple />
+    <plate>
+      <orange class="small" />
+    </plate>
+    <pickle class="small" />
+    `
+  },
+  {
+    selectorName: "Attribute Selector",
+    helpTitle: "Select all elements that have a specific attribute",
+    doThis : "Select the items for someone",
+    selector : "[for]",
+    syntax: "[attribute]",
+    help : "It does not matter what the value of the attribute is, it can even be blank.",
+    examples : [
+      '<strong>a[href]</strong> selects all <tag>a</tag> elements that have a <strong>href="anything"</strong> attribute.',
+      '<strong>[id]</strong> selects all elements that have a <strong>href="anything"</strong>. attribute'
+    ],
+    boardMarkup:`
+    <bento><apple class="small"/></bento>
+    <apple for="Ethan"/>
+    <plate for="Alice"><pickle/></plate>
+    <bento for="Clara"><orange/></bento>
+    <pickle/>`
+  },
+  {
+    selectorName: "Attribute Selector",
+    helpTitle: "Select all elements that have a specific attribute",
+    doThis : "Select the plates for someone",
+    selector : "plate[for]",
+    syntax: "A[attribute]",
+    help : "You can combine the attribute selector with other selectors, like the tag name selector.",
+    examples : [
+      '<strong>[value]</strong> selects all elements that have a <strong>value="anything"</strong> attribute.',
+      '<strong>a[href]</strong> selects all <tag>a</tag> elements that have a <strong>href="anything"</strong> attribute.',
+      '<strong>input[disabled]</strong> selects all <tag>input</tag>strong> elements with the <strong>disabled</strong> attribute'
+    ],
+    boardMarkup:`
+    <plate for="Steve"><pickle/></plate>
+    <plate for="Luke"><apple/></plate>
+    <plate/>
+    <bento for="Sarah"><orange/></bento>
+    `
+  },
+  {
+    selectorName: "Attribute Value Selector",
+    helpTitle: "Select all elements that have a specific attribute value",
+    doThis : "Select Vitaly's meal",
+    selector : "[for=Vitaly]",
+    syntax: "A[attribute=value]",
+    help : "You can combine the attribute selector with other selectors, like the tag name selector.",
+    examples : [
+      '<strong>input[type=checkbox]</strong> selects all checkbox input elements.'
+    ],
+    boardMarkup:`
+    <apple for="Alexei" />
+    <bento for="Albina"><apple /></bento>
+    <bento for="Vitaly"><orange/></bento>
+    <pickle/>
+    `
+  },
+  {
+    selectorName: "Attribute Starts With Selector",
+    helpTitle: "Select all elements with an attribute value that starts with specific characters",
+    doThis : "Select the items for names that start with 'Sa'",
+    selector : "[for^='Sa']",
+    syntax: "[attribute^=value]",
+    help : 'Attribute selectors are case sensitive, each character must match exactly.',
+    examples : [
+      '<strong>.toy[category^=Swim]</strong> selects elements with class <strong>toy</strong> and either <strong>category="Swimwear</strong> or <strong>category="Swimming</strong>".'
+    ],
+    boardMarkup: `
+    <plate for="Sam"><pickle/></plate>
+    <bento for="Sarah"><apple class="small"/></bento>
+    <bento for="Mary"><orange/></bento>
+    `
+  },
+  {
+    selectorName: "Attribute Ends With Selector",
+    helpTitle: "Select all elements with an attribute value that ends with specific characters",
+    doThis : "Select the items for names that end with 'ato'",
+    selector : "[for$='ato']",
+    syntax: "[attribute$=value]",
+    help : '',
+    examples : [
+      '<strong>img[src$=.jpg]</strong> selects all images display a <strong>.jpg</strong> image.',
+    ],
+    boardMarkup:`
+    <apple class="small"/>
+    <bento for="Hayato"><pickle/></bento>
+    <apple for="Ryota"></apple>
+    <plate for="Minato"><orange/></plate>
+    <pickle class="small"/>
+    `
+  },
+  {
+    selectorName: "Attribute Wildcard Selector",
+    helpTitle: "Select all elements with an attribute value that ends contains specific characters",
+    syntax: "[attribute*=value]",
+    doThis : "Select the meals for names that contain 'obb'",
+    selector : "[for*='obb']",
+    help : '',
+    examples : [
+      '<strong>:not(#fancy)</strong> selects all elements that do not have <strong>id="fancy"</strong>.'
+    ],
+    boardMarkup:`
+    <bento for="Robbie"><apple /></bento>
+    <bento for="Timmy"><pickle /></bento>
+    <bento for="Bobby"><orange /></bento>
+    `
   }
 ];


### PR DESCRIPTION
- New levels 27-32 are about attribute selectors
  - Rewrite of how level markup is stored in `levels.js`
  - Attributes are shown on little name cards
- Added next and previous level navigation arrows
- Added a "Reset Progress" button to clear out progress history
- Added little pop animations when items appear on the table
- Changed some levels to better "enforce" the use of the desired selector
- Cleaned up the example copy in `levels.js` to use the `<tag>` elements
