### PR TITLE
Fix level 28 markup

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -590,7 +590,7 @@ var levels = [
     examples : [
       '<strong>[value]</strong> selects all elements that have a <strong>value="anything"</strong> attribute.',
       '<strong>a[href]</strong> selects all <tag>a</tag> elements that have a <strong>href="anything"</strong> attribute.',
-      '<strong>input[disabled]</strong> selects all <tag>input</tag>strong> elements with the <strong>disabled</strong> attribute'
+      '<strong>input[disabled]</strong> selects all <tag>input</tag> elements with the <strong>disabled</strong> attribute'
     ],
     boardMarkup:`
     <plate for="Sarah"><pickle/></plate>


### PR DESCRIPTION
![lvl-28](https://cloud.githubusercontent.com/assets/657395/22554619/6ab9b8f6-e969-11e6-9d14-d431ea65bbe4.png)
removed redundand `strong>` in level 28