### PR TITLE
Allow .table as a selectorTable

### DIFF
--- a/js/restaurant.js
+++ b/js/restaurant.js
@@ -386,7 +386,8 @@ function fireRule(rule) {
   * This resolves the  "Match all the things!" level from beheading the table too.
   * Relatedly, watching that happen made me nearly spill my drink.
   */
-
+  rule = rule.replace('.table', '');
+  
   // var baseTable = $('.table-wrapper > .table, .table-wrapper > .nametags, .table-wrapper > .table-surface');
   var baseTable = $('.table');
 

--- a/js/restaurant.js
+++ b/js/restaurant.js
@@ -262,8 +262,12 @@ function showTooltip(el){
   var tableElements = $(".table *");
   var index = tableElements.index(el);
   var that = el;
-  $(".markup > div *").eq(index).addClass("enhance").find("*").addClass("enhance");
-
+  if (index === -1) {
+    $(".markup > div").addClass("enhance").find("*").addClass("enhance");
+  } else {
+    $(".markup > div *").eq(index).addClass("enhance").find("*").addClass("enhance");
+  }
+  
   var helper = $(".helper");
 
   var pos = el.offset();

--- a/js/restaurant.js
+++ b/js/restaurant.js
@@ -126,6 +126,10 @@ $(document).ready(function(){
   });
 
   //Add tooltips
+  $(".table").on("mouseover",function(e){
+    e.stopPropagation();
+    showTooltip($(this));
+  });
   $(".table").on("mouseover","*",function(e){
     e.stopPropagation();
     showTooltip($(this));
@@ -146,6 +150,10 @@ $(document).ready(function(){
     hideTooltip();
   });
 
+  $(".table").on("mouseout", function(e){
+    hideTooltip();
+    e.stopPropagation();
+  });
   $(".table").on("mouseout","*", function(e){
     hideTooltip();
     e.stopPropagation();
@@ -387,7 +395,7 @@ function fireRule(rule) {
   * Relatedly, watching that happen made me nearly spill my drink.
   */
   rule = rule.replace('.table', '');
-  
+
   // var baseTable = $('.table-wrapper > .table, .table-wrapper > .nametags, .table-wrapper > .table-surface');
   var baseTable = $('.table');
 


### PR DESCRIPTION
Fix #133 

-  the `.table` selector is ignored in the rule check.
- add tooltip to the table
- highlight table in markup on hover