### PR TITLE
Fix GitHub capitalisation

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ p {
           Made by <a href="http://www.twitter.com/flukeout">@flukeout</a> &mdash; come say hi!
         </p>
         <p>
-          Have feedback or questions? Please file an issue on <a href="https://github.com/flukeout/css-diner/issues">the Github repo</a>.
+          Have feedback or questions? Please file an issue on <a href="https://github.com/flukeout/css-diner/issues">the GitHub repo</a>.
         </p>
       </div>
 


### PR DESCRIPTION
A minor issue, but a bit of a pet peeve of mine... This PR updates the website's hyperlink to the GitHub repo to use the correct capitalisation (previously 'Github')