### PR TITLE
"Adding one more example and one more selector type so the learner can keep track of two method calls.

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -393,7 +393,7 @@ var levels = [
     selectorName: "Nth Last Child Selector",
     helpTitle: "Select an element by its order in another element, counting from the back",
     doThis : "Select the 1st bento",
-    selector : "bento:nth-last-child(3)",
+    selector : ["bento:nth-last-child(3)", "bento:nth-of-type(1)"], // Array for multiple selectors
     syntax: ":nth-last-child(A)",
     help : "Selects the children from the bottom of the parent. This is like nth-child, but counting from the back!",
     examples : [

--- a/js/levels.js
+++ b/js/levels.js
@@ -399,6 +399,16 @@ var levels = [
     examples : [
       '<strong>:nth-last-child(2)</strong> selects all second-to-last child elements.'
     ],
+    // Adding Nth-of-Type information
+    additionalInfo: {
+      selectorName: "Nth-of-Type Selector",
+      helpTitle: "Select an element based on its occurrence among siblings of the same type.",
+      syntax: ":nth-of-type(A)",
+      help: "Targets elements of the same type by their position within a parent, counting from the start. Similar to :nth-child, but it only considers siblings of the same type, not all child elements.",
+      examples: [
+        '<strong>p:nth-of-type(3)</strong> selects the third `<p>` element within its parent.'
+      ]
+    },
     boardMarkup: `
     <plate/>
     <bento/>

--- a/js/levels.js
+++ b/js/levels.js
@@ -397,9 +397,10 @@ var levels = [
     syntax: ":nth-last-child(A)",
     help : "Selects the children from the bottom of the parent. This is like nth-child, but counting from the back!",
     examples : [
-      '<strong>:nth-last-child(2)</strong> selects all second-to-last child elements.'
+      '<strong>:nth-last-child(2)</strong> selects all second-to-last child elements.',
+      '<strong>p:nth-last-child(3)</strong> selects the third-to-last `<p>` element within its parent.', // added new example for better understanding
     ],
-    // Adding Nth-of-Type information
+    // also another apporch: Adding Nth-of-Type information
     additionalInfo: {
       selectorName: "Nth-of-Type Selector",
       helpTitle: "Select an element based on its occurrence among siblings of the same type.",


### PR DESCRIPTION
- There's some issue but adding one more example can help,
`p:nth-last-child(3) `selects the third-to-last `<p>` element within its parent.'
* Warning: Ensure proper syntax! `:nth-of-type` only works for elements of the same type.

###  Addition : Nth-of-Type Selector
Select an element based on its occurrence among siblings of the same type.
## ` :nth-of-type(A)` ##
Targets elements of the same type by their position within a parent, counting from the start. Similar to `:nth-child`, but it only considers siblings of the same type, not all child elements.<p>
Example
` p:nth-of-type(3)`
This selects the third `<p> `element within its parent.



